### PR TITLE
[480 550] Add single build batch mode

### DIFF
--- a/example-build-error.json
+++ b/example-build-error.json
@@ -1,0 +1,5 @@
+{
+  "callbacks": [],
+  "build_script": "#!/bin/sh\necho error\nexit 1\n",
+  "git_url": "git@github.com:mildred/hello.git"
+}

--- a/example-build.json
+++ b/example-build.json
@@ -1,0 +1,5 @@
+{
+  "callbacks": [],
+  "build_script": "#!/bin/sh\necho hello World\n",
+  "git_url": "git@github.com:mildred/hello.git"
+}

--- a/handlers/builds_test.go
+++ b/handlers/builds_test.go
@@ -23,7 +23,7 @@ func TestBuildHTTPWait(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	handler := BuildsHandler(ctx, tmp_dir)
+	handler := NewBuildsHandler(ctx, tmp_dir, false)
 	test_dir, err := os.Getwd()
 	if err != nil {
 		t.Fatal(err)
@@ -85,7 +85,7 @@ func TestBuildHTTPCallback(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	handler := BuildsHandler(ctx, tmp_dir)
+	handler := NewBuildsHandler(ctx, tmp_dir, false)
 	test_dir, err := os.Getwd()
 	if err != nil {
 		t.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"log"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"syscall"
 
 	"github.com/braintree/manners"
+	"github.com/squarescale/simple-builder/build"
 	"github.com/squarescale/simple-builder/handlers"
 )
 
@@ -33,18 +35,46 @@ func GetenvDef(name, def string) string {
 func main() {
 	log.Printf("Starting Simple Builder version %s...", version)
 
+	var buildJobFile string
 	httpAddr := os.Getenv("NOMAD_ADDR_http")
 	if httpAddr == "" {
 		httpAddr = "localhost:80"
 	}
 
 	flag.StringVar(&httpAddr, "http", httpAddr, "Listening address")
+	flag.StringVar(&buildJobFile, "build-job", "", "Build job file (single job mode)")
 	flag.Parse()
+
+	var wg sync.WaitGroup
+	ctx, cancelContext := context.WithCancel(context.Background())
+
+	var singleBuildDescriptor handlers.BuildDescriptorWithCallback
+	var singleBuildMode bool
+	var singleBuild *build.Build
+	var err error
+	if buildJobFile != "" {
+		log.Printf("Single build mode with %s", buildJobFile)
+		singleBuildMode = true
+		singleBuildDescriptor, err = parseJobFile(buildJobFile)
+		if err != nil {
+			log.Print(err)
+			os.Exit(1)
+			return
+		}
+	}
 
 	log.Printf("HTTP service listening on %s", httpAddr)
 
-	ctx, cancelContext := context.WithCancel(context.Background())
-	buildsHandler = handlers.NewBuildsHandler(ctx, "")
+	buildsHandler = handlers.NewBuildsHandler(ctx, "", singleBuildMode)
+	if singleBuildMode {
+		singleBuild, _, err = buildsHandler.CreateBuild(&wg, singleBuildDescriptor)
+		if err != nil {
+			log.Print(err)
+			os.Exit(1)
+			return
+		}
+	}
+
 	mux := http.NewServeMux()
 	mux.Handle("/version", handlers.VersionHandler(version))
 	mux.Handle("/health", handlers.HealthHandler(&Health, &Health.Status, &Health.Lock))
@@ -67,5 +97,51 @@ func main() {
 		httpServer.Close()
 	}()
 
-	log.Fatal(httpServer.ListenAndServe())
+	if singleBuildMode {
+		var exitCode int = 1
+		buildEnd := make(chan struct{})
+		httpEnd := make(chan struct{})
+
+		go func() {
+			defer close(buildEnd)
+			wg.Wait()
+		}()
+
+		go func() {
+			defer close(httpEnd)
+			err = httpServer.ListenAndServe()
+			if err != nil {
+				log.Print(err)
+			}
+		}()
+
+		select {
+		case <-buildEnd:
+			if len(singleBuild.Errors) == 0 {
+				exitCode = 0
+			}
+			cancelContext()
+			httpServer.Close()
+		case <-ctx.Done():
+		}
+
+		<-httpEnd
+		os.Exit(exitCode)
+
+	} else {
+		err = httpServer.ListenAndServe()
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+}
+
+func parseJobFile(filename string) (b handlers.BuildDescriptorWithCallback, err error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return b, err
+	}
+	defer f.Close()
+	err = json.NewDecoder(f).Decode(&b)
+	return b, err
 }


### PR DESCRIPTION
Single build mode: the build job is given as JSON rom command line.
Creating new builds is disabled on HTTP. The program stops as soon as the
build is finished and the callbacks are dispatched.

LLR: https://github.com/squarescale/platform/issues/550
HLR: https://github.com/squarescale/platform/issues/480